### PR TITLE
Feature/issue2

### DIFF
--- a/TrabajoPractico1/src/Main.java
+++ b/TrabajoPractico1/src/Main.java
@@ -1,32 +1,37 @@
 /*
 Hilo principal
- */
+*/
+public class Main {
+    private static final int CANTIDAD_JOBS = 500;
+    private static final int CANTIDAD_SCHEDULERS = 3;
 
-void main() {
-/*
-========================================================================================================================
-Primera seccion del Main
-========================================================================================================================
-Inicializar todas las JobsQueue (5) , 1 por cada estado en el que puede estar un Job
-Inicializar NodeMatrix con 200 nodos
-========================================================================================================================
- */
+    public static void main(String[] args) {
+        JobQueue creados = new JobQueue();                  // Cola de jobs creados
+        JobQueue enCola = new JobQueue();                   // Cola de jobs en espera de validacion
+        JobQueue enEjecucion = new JobQueue();              // Cola de jobs en ejecucion
+        JobQueue finalizados = new JobQueue();              // Cola de jobs finalizados
+        JobQueue fallidos = new JobQueue();                 // Cola de jobs fallidos
+        JobQueue validados = new JobQueue();                // Cola de jobs validados
 
+        NodeMatrix matriz = new NodeMatrix();               // Matriz de nodos
 
-    /*
-========================================================================================================================
-Segunda seccion del Main
-========================================================================================================================
-Se inicializan todas las clases runnable
-========================================================================================================================
- */
+        for (int i = 0; i < CANTIDAD_JOBS; i++) {
+            creados.pushJob(new Job(i, EstadoJob.EN_COLA)); // Creo los jobs y los agrego a la cola de creados
+        }
 
+        Scheduler scheduler = new Scheduler(enCola, creados, matriz);   // Creo el scheduler, le paso las colas y la matriz de nodos
+        Thread[] schedulerThreads = new Thread[CANTIDAD_SCHEDULERS];   // Creo los hilos del scheduler
 
-    /*
-========================================================================================================================
-Tercera seccion del Main
-========================================================================================================================
-Se inicializan los hilos
-========================================================================================================================
- */
+        for (int i = 0; i < CANTIDAD_SCHEDULERS; i++) {
+            schedulerThreads[i] = new Thread(scheduler, "Scheduler-" + (i + 1)); // Creo cada hilo del scheduler con un nombre identificativo
+        }
+
+        /*
+        Estos hilos quedan preparados, pero conviene iniciarlos junto con PreExecutionCheck.
+        Si se ejecuta Scheduler solo con 500 jobs, despues de ocupar 200 nodos nadie libera
+        recursos y los hilos quedan esperando nodos disponibles.
+        */
+        System.out.println("Sistema inicializado con " + CANTIDAD_JOBS + " jobs y " + CANTIDAD_SCHEDULERS + " schedulers.");
+
+    }
 }

--- a/TrabajoPractico1/src/NodeMatrix.java
+++ b/TrabajoPractico1/src/NodeMatrix.java
@@ -36,7 +36,7 @@ public class NodeMatrix {
         }
     }
 
-        private Node ocuparNodoAleatorio(){
+        public Node ocuparNodoAleatorio(){
 
 /*
 sheduler necesita saber que nodo ocupar para asignar el job

--- a/TrabajoPractico1/src/Scheduler.java
+++ b/TrabajoPractico1/src/Scheduler.java
@@ -10,11 +10,13 @@ Ejecutado por 3 hilos
                   -> Job se registra en *JobsEnCola*
 
 */
-public class Scheduler implements Runnable{
+public class Scheduler implements Runnable {
 
-    JobQueue enCola;
-    JobQueue creados;
-    NodeMatrix matriz;
+    private static final int DEMORA_MS = 100;
+
+    private final JobQueue enCola;
+    private final JobQueue creados;
+    private final NodeMatrix matriz;
 
     public Scheduler(JobQueue enCola, JobQueue creados, NodeMatrix matriz) {
         this.enCola = enCola;
@@ -23,23 +25,49 @@ public class Scheduler implements Runnable{
     }
 
     @Override
-    public void run(){
-        Job job = creados.popJob(); // saco un job de los creados
-        if (job != null) { // si hay un job para procesar
-            Node nodo = matriz.ocuparNodoAleatorio(); // intento ocupar un nodo aleatorio
+    public void run() {
+        Job job = creados.popJob();
 
-            while (nodo == null) { // si no pude ocupar un nodo, sigo intentando
-                nodo = matriz.ocuparNodoAleatorio();
-                if(nodo == null) {
-                    try {
-                        Thread.sleep(100); // espero un poco antes de intentar de nuevo para evitar un ciclo muy rápido
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt(); // restablecer el estado de interrupción
-                    }
-                }
+        while (job != null) {
+            Node nodo = buscarNodoDisponible();
+
+            if (nodo == null) {
+                return;
             }
-            job.setAssignedNodeId(nodo.getID()); // asigno el nodo al job
-            enCola.pushJob(job); // agrego el job a la cola de jobs en espera de validacion
+
+            job.setAssignedNodeId(nodo.getID());
+            job.setEstado(EstadoJob.EN_COLA);
+            enCola.pushJob(job);
+
+            if (!esperarDemora()) {
+                return;
+            }
+
+            job = creados.popJob();
+        }
+    }
+
+    private Node buscarNodoDisponible() {
+        Node nodo = matriz.ocuparNodoAleatorio();
+
+        while (nodo == null) {
+            if (!esperarDemora()) {
+                return null;
+            }
+
+            nodo = matriz.ocuparNodoAleatorio();
+        }
+
+        return nodo;
+    }
+
+    private boolean esperarDemora() {
+        try {
+            Thread.sleep(DEMORA_MS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 }

--- a/TrabajoPractico1/src/Scheduler.java
+++ b/TrabajoPractico1/src/Scheduler.java
@@ -11,7 +11,35 @@ Ejecutado por 3 hilos
 
 */
 public class Scheduler implements Runnable{
-    public void run(){
 
+    JobQueue enCola;
+    JobQueue creados;
+    NodeMatrix matriz;
+
+    public Scheduler(JobQueue enCola, JobQueue creados, NodeMatrix matriz) {
+        this.enCola = enCola;
+        this.creados = creados;
+        this.matriz = matriz;
+    }
+
+    @Override
+    public void run(){
+        Job job = creados.popJob(); // saco un job de los creados
+        if (job != null) { // si hay un job para procesar
+            Node nodo = matriz.ocuparNodoAleatorio(); // intento ocupar un nodo aleatorio
+
+            while (nodo == null) { // si no pude ocupar un nodo, sigo intentando
+                nodo = matriz.ocuparNodoAleatorio();
+                if(nodo == null) {
+                    try {
+                        Thread.sleep(100); // espero un poco antes de intentar de nuevo para evitar un ciclo muy rápido
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt(); // restablecer el estado de interrupción
+                    }
+                }
+            }
+            job.setNodoAsignado(nodo); // asigno el nodo al job
+            enCola.pushJob(job); // agrego el job a la cola de jobs en espera de validacion
+        }
     }
 }

--- a/TrabajoPractico1/src/Scheduler.java
+++ b/TrabajoPractico1/src/Scheduler.java
@@ -38,7 +38,7 @@ public class Scheduler implements Runnable{
                     }
                 }
             }
-            job.setNodoAsignado(nodo); // asigno el nodo al job
+            job.setAssignedNodeId(nodo.getID()); // asigno el nodo al job
             enCola.pushJob(job); // agrego el job a la cola de jobs en espera de validacion
         }
     }

--- a/TrabajoPractico1/src/SchedulerTest.java
+++ b/TrabajoPractico1/src/SchedulerTest.java
@@ -1,0 +1,65 @@
+public class SchedulerTest {
+    private static final int CANTIDAD_JOBS = 30;
+    private static final int CANTIDAD_SCHEDULERS = 3;
+
+    public static void main(String[] args) throws InterruptedException {
+        JobQueue creados = new JobQueue();
+        JobQueue enCola = new JobQueue();
+        NodeMatrix matriz = new NodeMatrix();
+
+        for (int i = 0; i < CANTIDAD_JOBS; i++) {
+            creados.pushJob(new Job(i, EstadoJob.EN_COLA));
+        }
+
+        Scheduler scheduler = new Scheduler(enCola, creados, matriz);
+        Thread[] hilos = new Thread[CANTIDAD_SCHEDULERS];
+
+        for (int i = 0; i < CANTIDAD_SCHEDULERS; i++) {
+            hilos[i] = new Thread(scheduler, "SchedulerTest-" + (i + 1));
+            hilos[i].start();
+        }
+
+        for (Thread hilo : hilos) {
+            hilo.join(5000);
+            if (hilo.isAlive()) {
+                throw new AssertionError("El scheduler no termino dentro del tiempo esperado.");
+            }
+        }
+
+        if (!creados.isEmpty()) {
+            throw new AssertionError("Quedaron jobs sin procesar en la cola de creados.");
+        }
+
+        boolean[] idsProcesados = new boolean[CANTIDAD_JOBS];
+        int jobsEnCola = 0;
+        Job job = enCola.popJob();
+
+        while (job != null) {
+            if (job.getAssignedNodeId() < 0) {
+                throw new AssertionError("El job " + job.getID() + " no tiene nodo asignado.");
+            }
+
+            if (job.getEstado() != EstadoJob.EN_COLA) {
+                throw new AssertionError("El job " + job.getID() + " no quedo en estado EN_COLA.");
+            }
+
+            if (job.getID() < 0 || job.getID() >= CANTIDAD_JOBS) {
+                throw new AssertionError("El job tiene un ID fuera de rango: " + job.getID());
+            }
+
+            if (idsProcesados[job.getID()]) {
+                throw new AssertionError("El job " + job.getID() + " fue procesado mas de una vez.");
+            }
+
+            idsProcesados[job.getID()] = true;
+            jobsEnCola++;
+            job = enCola.popJob();
+        }
+
+        if (jobsEnCola != CANTIDAD_JOBS) {
+            throw new AssertionError("Se esperaban " + CANTIDAD_JOBS + " jobs en cola, pero hubo " + jobsEnCola + ".");
+        }
+
+        System.out.println("SchedulerTest OK: todos los jobs fueron asignados y enviados a enCola.");
+    }
+}


### PR DESCRIPTION
📄 Descripción

Se implementa la etapa Scheduler del sistema concurrente. Esta etapa toma jobs creados, les asigna un nodo disponible de la matriz de nodos y los envía a la cola de jobs en espera de validación.

⚙️ Cambios realizados

- Se corrigió `Main` para que el proyecto tenga un punto de entrada válido.
- Se inicializan las colas principales del sistema.
- Se crean los 500 jobs requeridos por el enunciado.
- Se inicializa la matriz de 200 nodos.
- Se preparan los 3 hilos correspondientes a la etapa Scheduler.
- Se implementó la lógica de `Scheduler` para procesar jobs en loop hasta vaciar la cola de jobs creados.
- Se utiliza `NodeMatrix.ocuparNodoAleatorio()` para asignar nodos sin modificar directamente su estado desde `Scheduler`.
- Se asigna el id del nodo al job y se cambia el estado del job a `EN_COLA`.
- Se agregó `SchedulerTest` para validar el funcionamiento aislado de la etapa Scheduler.

🧪 Cómo probarlo

Compilar el proyecto:

```bash
javac TrabajoPractico1/src/*.java
```

Ejecutar el test del Scheduler:

```bash
java -cp TrabajoPractico1/src SchedulerTest
```

Resultado esperado:

```bash
SchedulerTest OK: todos los jobs fueron asignados y enviados a enCola.
```

También se puede ejecutar `Main` para verificar la inicialización del sistema:

```bash
java -cp TrabajoPractico1/src Main
```

Resultado esperado:

```bash
Sistema inicializado con 500 jobs y 3 schedulers.
```

⚠️ Checklist

- [x] Compila
- [x] Funciona correctamente
- [x] No rompe otras partes
```

nota para la PR: aclararía que `Main` todavía no inicia todos los hilos porque falta integrar la etapa `PreExecutionCheck`; si se corre Scheduler solo con 500 jobs, puede quedarse esperando cuando se ocupan los 200 nodos.