### PR TITLE
feat: add node statistics logging and implement obtenerEstadisticasNo…

### DIFF
--- a/TrabajoPractico1/src/Main.java
+++ b/TrabajoPractico1/src/Main.java
@@ -120,6 +120,7 @@ public class Main {
         esperarHilos(postProcessingThreads);
 
         double tiempoTotalSegundos = (System.nanoTime() - tiempoInicio) / 1_000_000_000.0;
+        registrarEstadisticasNodos(log, matriz);
         registrar(log, String.format("Sistema finalizado. Tiempo de ejecucion: %.2f segundos.", tiempoTotalSegundos));
     }
 
@@ -127,6 +128,17 @@ public class Main {
         String mensajeConFecha = "[" + LocalDateTime.now().format(LOG_FORMATTER) + "] " + mensaje;
         System.out.println(mensaje);
         log.println(mensajeConFecha);
+    }
+
+    private static void registrarEstadisticasNodos(PrintWriter log, NodeMatrix matriz) {
+        registrar(log, "Estadisticas de nodos:");
+        String[] lineas = matriz.obtenerEstadisticasNodos().split("\\R");
+
+        for (String linea : lineas) {
+            if (!linea.isEmpty()) {
+                registrar(log, linea);
+            }
+        }
     }
 
     private static void esperarHilos(Thread[] threads) {

--- a/TrabajoPractico1/src/NodeMatrix.java
+++ b/TrabajoPractico1/src/NodeMatrix.java
@@ -1,4 +1,3 @@
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /*
@@ -119,6 +118,77 @@ public class NodeMatrix {
          * servicio.
          */
         return setFueradeServicio(idNodo);
+    }
+
+    public String obtenerEstadisticasNodos() {
+        LockPrinter.lock();
+        try {
+            int libres = 0;
+            int ocupados = 0;
+            int fueraDeServicio = 0;
+            int totalEjecuciones = 0;
+            int nodosSinEjecuciones = 0;
+            int maxEjecuciones = 0;
+
+            for (Node nodo : nodos) {
+                if (nodo.getEstado() == EstadoNode.LIBRE) {
+                    libres++;
+                } else if (nodo.getEstado() == EstadoNode.OCUPADO) {
+                    ocupados++;
+                } else if (nodo.getEstado() == EstadoNode.FUERA_DE_SERVICIO) {
+                    fueraDeServicio++;
+                }
+
+                int ejecuciones = nodo.getContadorEjecuciones();
+                totalEjecuciones += ejecuciones;
+
+                if (ejecuciones == 0) {
+                    nodosSinEjecuciones++;
+                }
+
+                if (ejecuciones > maxEjecuciones) {
+                    maxEjecuciones = ejecuciones;
+                }
+            }
+
+            StringBuilder estadisticas = new StringBuilder();
+            estadisticas.append("Total de nodos: ").append(cantidadNodos).append(System.lineSeparator());
+            estadisticas.append("Nodos libres: ").append(libres).append(System.lineSeparator());
+            estadisticas.append("Nodos ocupados: ").append(ocupados).append(System.lineSeparator());
+            estadisticas.append("Nodos fuera de servicio: ").append(fueraDeServicio).append(System.lineSeparator());
+            estadisticas.append("Total de asignaciones a nodos: ").append(totalEjecuciones).append(System.lineSeparator());
+            estadisticas.append("Nodos sin ejecuciones asignadas: ").append(nodosSinEjecuciones).append(System.lineSeparator());
+            estadisticas.append("Mayor cantidad de ejecuciones en un nodo: ").append(maxEjecuciones).append(System.lineSeparator());
+            estadisticas.append("Nodos con mayor cantidad de ejecuciones: ");
+
+            boolean primero = true;
+            for (Node nodo : nodos) {
+                if (nodo.getContadorEjecuciones() == maxEjecuciones) {
+                    if (!primero) {
+                        estadisticas.append(", ");
+                    }
+                    estadisticas.append(nodo.getID());
+                    primero = false;
+                }
+            }
+
+            estadisticas.append(System.lineSeparator());
+            estadisticas.append("Detalle por nodo:").append(System.lineSeparator());
+
+            for (Node nodo : nodos) {
+                estadisticas.append("Nodo ")
+                        .append(nodo.getID())
+                        .append(" | Estado: ")
+                        .append(nodo.getEstado())
+                        .append(" | Ejecuciones: ")
+                        .append(nodo.getContadorEjecuciones())
+                        .append(System.lineSeparator());
+            }
+
+            return estadisticas.toString();
+        } finally {
+            LockPrinter.unlock();
+        }
     }
 
 }


### PR DESCRIPTION
📄 Descripción

Se agrega al log final del sistema una estadística completa de los nodos utilizados durante la ejecución. Esta información se registra una vez finalizado el procesamiento de los 500 jobs, cumpliendo con el requerimiento del enunciado de imprimir estadísticas de nodos al terminar el programa.

⚙️ Cambios realizados

- Se agregó en `NodeMatrix` el método `obtenerEstadisticasNodos()`.
- Se calcula la cantidad de nodos:
  - libres;
  - ocupados;
  - fuera de servicio.
- Se calcula el total de asignaciones realizadas a nodos.
- Se informa cuántos nodos no recibieron ejecuciones.
- Se identifica la mayor cantidad de ejecuciones asignadas a un nodo.
- Se listan los nodos con mayor cantidad de ejecuciones.
- Se agrega un detalle individual por nodo con:
  - id del nodo;
  - estado final;
  - cantidad de ejecuciones.
- Se actualizó `Main` para registrar estas estadísticas al finalizar la ejecución.

🧪 Cómo probarlo

Compilar el proyecto:

```bash
javac TrabajoPractico1/src/*.java
```

Ejecutar el programa:

```bash
java -cp TrabajoPractico1/src Main
```

Verificar que al final de la ejecución, tanto en consola como en el archivo de log, aparezca una sección similar a:

```text
Estadisticas de nodos:
Total de nodos: 200
Nodos libres: ...
Nodos ocupados: ...
Nodos fuera de servicio: ...
Total de asignaciones a nodos: 500
...
Detalle por nodo:
Nodo 0 | Estado: ... | Ejecuciones: ...
```

⚠️ Checklist

- [x] Compila
- [x] Registra estadísticas finales de nodos
- [x] Mantiene el log periódico de jobs cada 200 ms
- [x] No modifica la lógica de procesamiento de jobs
```